### PR TITLE
add CASE24 paper on world models and representation learning

### DIFF
--- a/papers.md
+++ b/papers.md
@@ -173,6 +173,8 @@ We list key challenges from a wide span of candidate concerns, as well as trendi
 
 <!-- <details><summary>(Click for details)</summary> -->
 
+- An Examination of Offline-Trained Encoders in Vision-Based Deep Reinforcement Learning for Autonomous Driving [[CASE2024]](https://ieeexplore.ieee.org/document/10711548)
+
 - Think2Drive: Efficient Reinforcement Learning by Thinking in Latent World Model for Quasi-Realistic Autonomous Driving (in CARLA-v2) [[ECCV2024]](https://arxiv.org/abs/2402.16720)
 
 - WoVoGen: World Volume-aware Diffusion for Controllable Multi-camera Driving Scene Generation [[ECCV2024]](https://arxiv.org/abs/2312.02934)[[Code]](https://github.com/fudan-zvg/WoVoGen)![](https://img.shields.io/github/stars/fudan-zvg/WoVoGen.svg?style=social&label=Star&maxAge=2592000)
@@ -508,6 +510,8 @@ We list key challenges from a wide span of candidate concerns, as well as trendi
 ## Visual Abstraction / Representation Learning
 
 <!-- <details><summary>(Click for details)</summary> -->
+
+- An Examination of Offline-Trained Encoders in Vision-Based Deep Reinforcement Learning for Autonomous Driving [[CASE2024]](https://ieeexplore.ieee.org/document/10711548)
 
 - Visual Point Cloud Forecasting enables Scalable Autonomous Driving [[CVPR2024]](https://arxiv.org/abs/2312.17655)[[Code]](https://github.com/OpenDriveLab/ViDAR)![](https://img.shields.io/github/stars/OpenDriveLab/ViDAR.svg?style=social&label=Star&maxAge=2592000)
 


### PR DESCRIPTION
Adds CASE 2024 paper "An Examination of Offline-Trained Encoders in Vision-Based Deep Reinforcement Learning for Autonomous Driving" to:
- World Model & Model-based RL, and
- Visual Abstraction / Representation Learning
